### PR TITLE
Fixes syntax errors in reference tags

### DIFF
--- a/_ecosystem-threats/ECO-0.md
+++ b/_ecosystem-threats/ECO-0.md
@@ -6,7 +6,7 @@
     ThreatOrigin:
     ExploitExample:
         - "BackStab: Mobile Backup Data Under Attack from Malware [^192]"
-        - "iOS 10: Security Weakness Discovered, Backup Passwords Much Easier to Break [^O.Afonin-1]"
+        - "iOS 10: Security Weakness Discovered, Backup Passwords Much Easier to Break [^O-Afonin-1]"
     CVEExample:
     PossibleCountermeasures:
         "As knowledge of the authentication credentials for any associated account (e.g., iTunes, Google) may facilitate an attacker\'s ability to initiate, access, or decrypt device backups, follow best practices for management of device account passwords.":

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -491,10 +491,10 @@
 
 [^250]: C. Liang and H. Chen, "TouchLogger: Inferring Keystrokes on Touch Screen from Smartphone Motion", presented at _6th USENIX Workshop on Hot Topics in Security_, 9 Aug. 2011; https://pdfs.semanticscholar.org/8c8c/f6ff0a88a5ae99360cada9afaf5439b61a8d.pdf [accessed 11/07/2016]
 
-[^J.Padgette-1]: J. Padgette et. al, Guide to Bluetooth Security, Draft SP 800-121 rev. 2, National Institute of Standards and Technology, 2016; http://csrc.nist.gov/publications/drafts/800-121/sp800_121_r2_draft.pdf [accessed 12/07/2016]
+[^J-Padgette-1]: J. Padgette et. al, Guide to Bluetooth Security, Draft SP 800-121 rev. 2, National Institute of Standards and Technology, 2016; http://csrc.nist.gov/publications/drafts/800-121/sp800_121_r2_draft.pdf [accessed 12/07/2016]
 
-[^O.Whitehouse-1]: O. Whitehouse, _War Nibbling: Bluetooth Insecurity_, white paper, 2003; www.wardriving.ch/hpneu/blue/doku/atstake_war_nibbling.pdf [accessed 12/07/2016]
+[^O-Whitehouse-1]: O. Whitehouse, _War Nibbling: Bluetooth Insecurity_, white paper, 2003; www.wardriving.ch/hpneu/blue/doku/atstake_war_nibbling.pdf [accessed 12/07/2016]
 
-[^O.Afonin-1]: O. Afononin, _TouchLogger: Inferring Keystrokes on Touch Screen from Smartphone Motion_, Elcomsoft Blog, 23 Sept 2016; https://blog.elcomsoft.com/2016/09/ios-10-security-weakness-discovered-backup-passwords-much-easier-to-break/ [accessed 12/9/2016]
+[^O-Afonin-1]: O. Afononin, _TouchLogger: Inferring Keystrokes on Touch Screen from Smartphone Motion_, Elcomsoft Blog, 23 Sept 2016; https://blog.elcomsoft.com/2016/09/ios-10-security-weakness-discovered-backup-passwords-much-easier-to-break/ [accessed 12/9/2016]
 
-[^D.Goodin-1]: D. Goodin, _Using Rowhammer bitflips to root Android phones is now a thing_, Ars Technica, 23 October 2016; http://arstechnica.com/security/2016/10/using-rowhammer-bitflips-to-root-android-phones-is-now-a-thing/ [accessed 12/15/2016]
+[^D-Goodin-1]: D. Goodin, _Using Rowhammer bitflips to root Android phones is now a thing_, Ars Technica, 23 October 2016; http://arstechnica.com/security/2016/10/using-rowhammer-bitflips-to-root-android-phones-is-now-a-thing/ [accessed 12/15/2016]

--- a/_lan-pan-threats/LPN-10.md
+++ b/_lan-pan-threats/LPN-10.md
@@ -7,6 +7,6 @@
     ExploitExample: "Studying Bluetooth Malware Propagation: The BlueBag Project [^30]"
     CVEExample:
     PossibleCountermeasures:
-        "To reduce the opportunity for an attacker to conduct this attack, disable Bluetooth on vulnerable (circa 2004) devices when that feature is not in use. [^J.Padgette-1]":
+        "To reduce the opportunity for an attacker to conduct this attack, disable Bluetooth on vulnerable (circa 2004) devices when that feature is not in use. [^J-Padgette-1]":
             - Mobile Device User
 ---

--- a/_lan-pan-threats/LPN-14.md
+++ b/_lan-pan-threats/LPN-14.md
@@ -4,7 +4,7 @@
     ID: LPN-14
     Threat: "Bluejacking - sending unsolicited messages to a bluetooth-enabled mobile device"
     ThreatDescription: "The Bluetooth specification supports the transfer of certain object types defined in the OBEX protocol, namedly vCard (contacts), vCal (calendar events) and vNote (text). OBEX does not require authentication, and messages can be sent to Bluetooth-enabled devices without any prerequisite pairing or authentication. While unsolicited messages are not directly harmful to the device, they may facilitate social engineering attacks if a recipient accepts crafted contact or calendar information sent by an attacker."
-    ThreatOrigin: "Guide to Bluetooth Security: Draft NIST SP 800-121rev2 [^J.Padgette-1]"
+    ThreatOrigin: "Guide to Bluetooth Security: Draft NIST SP 800-121rev2 [^J-Padgette-1]"
     ExploitExample:
     CVEExample:
     PossibleCountermeasures:

--- a/_lan-pan-threats/LPN-15.md
+++ b/_lan-pan-threats/LPN-15.md
@@ -4,7 +4,7 @@
     ID: LPN-15
     Threat: "Secure Simple Pairing attacks"
     ThreatDescription: "An attacker may be able to force or entice a Bluetooth device to participate in Just Works SSP, which is susceptible to MiTM attacks."
-    ThreatOrigin: "Guide to Bluetooth Security: Draft NIST SP 800-121rev2 [^J.Padgette-1]"
+    ThreatOrigin: "Guide to Bluetooth Security: Draft NIST SP 800-121rev2 [^J-Padgette-1]"
     ExploitExample:
     CVEExample:
     PossibleCountermeasures:

--- a/_lan-pan-threats/LPN-16.md
+++ b/_lan-pan-threats/LPN-16.md
@@ -3,7 +3,7 @@
     ThreatCategory: "Network Threats: Bluetooth"
     ID: LPN-16
     Threat: "Pairing eavesdropping attacks"
-    ThreatOrigin: "Guide to Bluetooth Security: NIST SP 800-121rev2) [^J.Padgette-1]"
+    ThreatOrigin: "Guide to Bluetooth Security: NIST SP 800-121rev2) [^J-Padgette-1]"
     ThreatDescription: "Bluetooth devices that pair using PIN/Legacy pairing (Bluetooth 2.0 and earlier) or low energy Legacy Pairing are vulnerable to eavesdropping. If an attacker can capture all pairing frames, the secret keys can be determined given enough time, facilitating device tracking, impersonation, and the decryption of data transmitted between devices for which secret keys are known."
     ExploitExample:
     CVEExample:

--- a/_lan-pan-threats/LPN-7.md
+++ b/_lan-pan-threats/LPN-7.md
@@ -3,7 +3,7 @@
     ThreatCategory: "Network Threats: Bluetooth"
     ID: LPN-7
     Threat: "BlueStumbling (a.k.a. Bluetooth War Walking) - discover, locate, and identify users based on their Bluetooth device addresses."
-    ThreatOrigin: "War Nibbling: Bluetooth Insecurity [^O.Whitehouse-1]"
+    ThreatOrigin: "War Nibbling: Bluetooth Insecurity [^O-Whitehouse-1]"
     ExploitExample:
     CVEExample:
     PossibleCountermeasures:

--- a/_stack-threats/STA-39.md
+++ b/_stack-threats/STA-39.md
@@ -3,7 +3,7 @@
     ThreatCategory: Mobile Operating System
     ID: STA-39
     Threat: "Deliberate rooting of device through inherent weaknesses in hardware"
-    ThreatOrigin: "Using Rowhammer bitflips to root Android phones is now a thing [^D.Goodin-1]"
+    ThreatOrigin: "Using Rowhammer bitflips to root Android phones is now a thing [^D-Goodin-1]"
     ExploitExample:
     CVEExample: CVE-2016-0823
     PossibleCountermeasures:


### PR DESCRIPTION
Dot (.) is apparently not an acceptable character within a reference tag. Changed all dots to hyphens.