### PR TITLE
Moved threat description to correct block

### DIFF
--- a/_application-threats/APP-2.md
+++ b/_application-threats/APP-2.md
@@ -3,7 +3,9 @@
     ThreatCategory: Vulnerable Applications
     ID: APP-2
     Threat: "App exposes sensitive information to untrusted apps"
-    ThreatOrigin: "Mobile OS APIs allow apps to share data with other apps, either by exposing specific services to other apps (e.g. Android intents) or by storing it to locations accessible to other apps. Sensitive information stored in commonly-accessible files/locations (e.g. OS-managed contacts list) or openly accessible through intents may be read or potentially modified by apps untrusted by the developer, which may lead to a loss of confidentiality, integrity, or availability of that data."
+    ThreatDescription: "Mobile OS APIs allow apps to share data with other apps, either by exposing specific services to other apps (e.g. Android intents) or by storing it to locations accessible to other apps. Sensitive information stored in commonly-accessible files/locations (e.g. OS-managed contacts list) or openly accessible through intents may be read or potentially modified by apps untrusted by the developer, which may lead to a loss of confidentiality, integrity, or availability of that data."
+    ThreatOrigin: 
+    
     ExploitExample:
         - "Vulnerability in Skype for Android [^67]"
         - "World Writable Code Is Bad, MMMMKAY [^68]"


### PR DESCRIPTION
Was under ThreatOrigin, so it was not displaying correctly.

Resolves #_corresponding issue number_
