### PR TITLE
WIP: Search engine balancing

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -38,7 +38,7 @@
         // a boost of 10 to indicate matches on this field are more important.
         var idx = lunr(function() {
             this.field('ThreatID', {
-                boost: 11
+                boost: 50
             });
             this.field('ThreatCategory');
             this.field('Threat', {


### PR DESCRIPTION
* Increase threat ID field boost. This ensures that matches on the threat ID field appear first in the list, instead of previously where they would not.