### PR TITLE
Update Github API to use proper authentication

### DIFF
--- a/_includes/issues.html
+++ b/_includes/issues.html
@@ -1,13 +1,14 @@
 <div id="github-issues" threatID="{{page.ID}}"></div>
 <ul id="issue-list"></ul>
 <script>
-    var github = "https://api.github.com/repos/usnistgov/mobile-threat-catalogue/issues?access_token=98bd69e6934fde706a6967ef44554812d51b866c";
+    var github = "https://api.github.com/repos/usnistgov/mobile-threat-catalogue/issues";
     var div = document.getElementById("github-issues");
     var ul = document.getElementById("issue-list");
     var threatID = div.getAttribute("threatID")
 
     request = new XMLHttpRequest();
     request.open('GET', github, true);
+    request.setRequestHeader("Authorization", "token 98bd69e6934fde706a6967ef44554812d51b866c");
 
     request.onload = function() {
         data = JSON.parse(request.responseText);


### PR DESCRIPTION
Using the access_token authorization method is deprecated as of a few months ago.