### PR TITLE
Reference 212: link leads to some crypto marketplace!

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -405,7 +405,7 @@
 
 [^211]: K. Nohl, Rooting SIM cards, presented at BlackHat, 2013. https://infocondb.org/con/black-hat/black-hat-usa-2013/rooting-sim-cards [accessed 7/27/22]
 
-[^212]: H. Ko and R. Caytiles, "A Review of Smartcard Security Issues," Journal of Security Engineering, 8, no. 3 (2011): 6. https://docplayer.net/23347975-A-review-of-smartcard-security-issues.html [accessed 10/11/21]
+[^212]: H. Ko and R. Caytiles, "A Review of Smartcard Security Issues," Journal of Security Engineering, 8, no. 3 (2011): 6. https://www.earticle.net/Article/A148181 [accessed 8/13/25]
 
 [^213]: zLabs, "Zimperium Applauds Google's Rapid Response to Unpatched Kernel Exploit," Zimperium, 25 Mar. 2016; https://blog.zimperium.com/zimperium-applauds-googles-rapid-response-to-unpatched-kernel-exploit/
 


### PR DESCRIPTION
opening the link redirects to https://pp.one/ which has nothing to do with the paper cited. Replace the faulty link with one from the publisher